### PR TITLE
Add GitHub Packages publish workflow and rename package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Set version from release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Publishing version: $VERSION"
+          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build
+
+      - name: Publish to GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
+          echo "@infobipcth:registry=https://npm.pkg.github.com" >> .npmrc
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "@van-ons/block-editor",
-  "version": "1.1.0",
+  "name": "@infobipcth/block-editor",
+  "version": "2.0.0",
   "description": "A standalone implementation of the WordPress Block Editor",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "keywords": [
     "block",
     "editor",


### PR DESCRIPTION
Rename package from @van-ons/block-editor to @infobipcth/block-editor, add publishConfig for GitHub Packages registry, and add publish.yml workflow that builds and publishes on GitHub Release (same pattern as agentos-chat). Bump version to 2.0.0.